### PR TITLE
Adds Deployer IAM to allow any given AWS account to deploy AWS resources in a single account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Generated
 dist/
 data/
+.aws-sam/
+.terraform/
+.terraform.lock.hcl
 
 # Observability
 logs/
@@ -13,6 +16,9 @@ __pycache__/
 
 # OS, Editor
 *.todo
+.vscode/
+.idea/
+*.DS_Store
 
 # Secret
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ data/
 .aws-sam/
 .terraform/
 .terraform.lock.hcl
+terraform.tfstate
 
 # Observability
 logs/

--- a/bff-api/Makefile
+++ b/bff-api/Makefile
@@ -4,31 +4,36 @@ PRE_COMMIT := pre-commit
 PYTHON := python3
 DIR := bff_api
 
-setup:
+# Generic dynamic help
+help:
+	@echo "Choose a command:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+setup: ## Setup the project
 	$(POETRY) shell
 	pip install pre-commit
 	poetry install
 	@make pre-commit-install
 
-install:
+install: ## Install dependencies
 	$(POETRY) install
 
-test:
+test: ## Run tests
 	$(POETRY) run pytest
 
-lint:
+lint: ## Run linter
 	$(POETRY) run pylint ${DIR}/ --rcfile=.pylintrc
 
-start:
+start: ## Start the server
 	$(POETRY) run python ${DIR}/main.py
 
-init-db:
+init-db: ## Initialize the database
 	$(POETRY) run python db/scripts/init_db/main.py
 
-pre-commit-install:
+pre-commit-install: ## Install pre-commit hooks
 	$(PRE_COMMIT) install
 
-pre-commit-run:
+pre-commit-run: ## Run pre-commit hooks
 	$(PRE_COMMIT) run --all-files
 
-.PHONY: install test lint start pre-commit-install pre-commit-run init-db
+.PHONY: help install test lint start pre-commit-install pre-commit-run init-db

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -1,0 +1,19 @@
+# Variables
+TERRAFORM := terraform
+
+# Generic dynamic help
+help:
+	@echo "Choose a command:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+
+deployer-iam-init: ## Initialize terraform
+	cd ./deployer-iam && $(TERRAFORM) init
+
+deployer-iam-plan: ## Plan terraform
+	cd ./deployer-iam && $(TERRAFORM) plan
+
+deployer-iam-apply: ## Apply terraform
+	cd ./deployer-iam && $(TERRAFORM) apply
+
+.PHONY: help tf-init tf-plan tf-apply

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -16,4 +16,4 @@ deployer-iam-plan: ## Plan terraform
 deployer-iam-apply: ## Apply terraform
 	cd ./deployer-iam && $(TERRAFORM) apply
 
-.PHONY: help tf-init tf-plan tf-apply
+.PHONY: help deployer-iam-init deployer-iam-plan deployer-iam-apply

--- a/deploy/deployer-iam/README.md
+++ b/deploy/deployer-iam/README.md
@@ -1,0 +1,26 @@
+# Deployer IAM
+
+This collection of Terraform files allows the manual, cli based creation of AWS resources on a single AWS account by users of different accounts. Why? To keep the deployments simple for this hackathon.
+
+## How to use this in your deployment
+
+1. Install Terraform and AWS CLI
+2. Configure AWS Credentials - Developers need AWS credentials (access key and secret) that have permission to assume the role created by Terraform. Typically, this will be their IAM user credentials.
+3. Assume the role - To use the deployment role, developers should configure their AWS CLI (or their environment variables) to assume the role. This can be done by adding a profile to their AWS configuration file `(~/.aws/config)` like:
+
+```
+[profile deployment]
+role_arn = arn:aws:iam::<LARRYS_ACCOUNT_ID>:role/deployment_role
+source_profile = default
+region = us-east-1
+```
+
+4. This will return temporary credentials (Access Key, Secret Key, and Session Token) which can be set as environment variables before running Terraform:
+
+```sh
+export AWS_ACCESS_KEY_ID=<temporary-access-key>
+export AWS_SECRET_ACCESS_KEY=<temporary-secret-key>
+export AWS_SESSION_TOKEN=<temporary-session-token>
+```
+
+5. Run `terraform plan` to see the plan and to deploy `terraform apply`

--- a/deploy/deployer-iam/README.md
+++ b/deploy/deployer-iam/README.md
@@ -5,14 +5,14 @@ This collection of Terraform files allows the manual, cli based creation of AWS 
 ## How to use this in your deployment
 
 1. Install Terraform and AWS CLI
-2. Configure AWS Credentials - Developers need AWS credentials (access key and secret) that have permission to assume the role created by Terraform. Typically, this will be their IAM user credentials.
-3. Assume the role - To use the deployment role, developers should configure their AWS CLI (or their environment variables) to assume the role. This can be done by adding a profile to their AWS configuration file `(~/.aws/config)` like:
+2. Configure AWS Credentials - Developers that need to deploy resources need to assume the `deployer-iam` role created by larry-dalmeida via the terraform files in `deployer-iam` directory. To allow them to assume the role, their AWS Account ID needs to be added to an allow list in the `allowed_principals` variable in `variables.tf`.
+3. Assume the role - To use the deployment role, developers should configure their AWS CLI to assume the role. This can be done by adding a profile to their AWS configuration file `(~/.aws/config)` like:
 
 ```
 [profile deployment]
 role_arn = arn:aws:iam::<LARRYS_ACCOUNT_ID>:role/deployment_role
 source_profile = default
-region = us-east-1
+region = eu-central-1
 ```
 
 4. This will return temporary credentials (Access Key, Secret Key, and Session Token) which can be set as environment variables before running Terraform:

--- a/deploy/deployer-iam/main.tf
+++ b/deploy/deployer-iam/main.tf
@@ -1,0 +1,40 @@
+resource "aws_iam_role" "deploy_role" {
+  name = var.deploy_role_name
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = {
+          AWS = var.allowed_principals
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy" "deploy_policy" {
+  name        = "${var.deploy_role_name}_policy"
+  description = "Policy to allow deployment of Lambda and S3 resources"
+  policy      = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = [
+          "lambda:*",
+          "s3:*",
+          "iam:PassRole"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "deploy_policy_attach" {
+  role       = aws_iam_role.deploy_role.name
+  policy_arn = aws_iam_policy.deploy_policy.arn
+}

--- a/deploy/deployer-iam/outputs.tf
+++ b/deploy/deployer-iam/outputs.tf
@@ -1,0 +1,4 @@
+output "deploy_role_arn" {
+  description = "ARN of the deployment IAM role"
+  value       = aws_iam_role.deploy_role.arn
+}

--- a/deploy/deployer-iam/variables.tf
+++ b/deploy/deployer-iam/variables.tf
@@ -1,0 +1,20 @@
+variable "region" {
+  description = "AWS region to deploy resources"
+  type        = string
+  default     = "eu-central-1"
+}
+
+variable "deploy_role_name" {
+  description = "The name of the IAM role used for deployments"
+  type        = string
+  default     = "deployment_role"
+}
+
+variable "allowed_principals" {
+  description = "List of IAM ARNs or AWS Account IDs allowed to assume the role"
+  type        = list(string)
+  default     = [
+    # rashmi-carol-dsouza
+    "arn:aws:iam::477896369815:root"
+  ]
+}

--- a/deploy/deployer-iam/versions.tf
+++ b/deploy/deployer-iam/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = "~> 1.10.2"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.88.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}


### PR DESCRIPTION
# Changes

- Enables any user/role in a permitted aws account to deploy resources to Larry's account
- Only used temporarily during the hackathon